### PR TITLE
added option for reliable queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ This jobs will be grouped into the single job with the single argument:
   # => [[5]]
   ```
 
+- `batch_ttl` is the number of seconds used by Supervisor to determine when a pending flush has expired and needs to be re-queued. Defaults to 3600.
+
 - `tests_env` is used to silence some logging in test environments (see below). Default: true if `Rails.env.test?`, false otherwise.
 
 ## Web UI
@@ -132,6 +134,7 @@ grouping:
   :poll_interval: 5       # Amount of time between polling batches
   :max_batch_size: 5000   # Maximum batch size allowed
   :lock_ttl: 1            # Batch queue flush lock timeout job enqueues
+  :reliable: true         # Enable reliable queueing and expired job supervisor
 ```
 
 Or set it in your code:
@@ -140,6 +143,7 @@ Or set it in your code:
 Sidekiq::Grouping::Config.poll_interval = 5
 Sidekiq::Grouping::Config.max_batch_size = 5000
 Sidekiq::Grouping::Config.lock_ttl = 1
+Sidekiq::Grouping::Config.reliable = true
 ```
 
 Note that you should set poll_interval option inside of sidekiq.yml to take effect. Setting this param in your ruby code won't change actual polling frequency.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ Useful for:
 * Grouping asynchronous API index calls into bulks for bulk updating/indexing.
 * Periodical batch updating of recently changing database counters.
 
-*NOTE:* As of 1.0 `batch_size` renamed to `batch_flush_size`.
-*NOTE:* As of 1.0.6 works with Sidekiq 4.
-*NOTE:* As of 1.0.8 Locking is atomic (set nx/ex) and will no longer lead to batches that are permalocked and stuck
+Please note:
+* As of 1.0 `batch_size` renamed to `batch_flush_size`.
+* As of 1.0.6 works with Sidekiq 4.
+* As of 1.0.8 Locking is atomic (set nx/ex) and will no longer lead to batches that are permalocked and stuck.
+* Enabling the `reliable` configuration option requires Redis 6.2 or higher.
 
 ## Usage
 

--- a/lib/sidekiq/grouping.rb
+++ b/lib/sidekiq/grouping.rb
@@ -13,7 +13,7 @@ module Sidekiq::Grouping
   autoload :Middleware, "sidekiq/grouping/middleware"
   autoload :Flusher, "sidekiq/grouping/flusher"
   autoload :FlusherObserver, "sidekiq/grouping/flusher_observer"
-  autoload :Lazarus, "sidekiq/grouping/lazarus"
+  autoload :Supervisor, "sidekiq/grouping/supervisor"
 
   class << self
     attr_writer :logger
@@ -31,7 +31,7 @@ module Sidekiq::Grouping
       @observer = Sidekiq::Grouping::FlusherObserver.new
       @task = Concurrent::TimerTask.new(execution_interval: interval) do
         Sidekiq::Grouping::Flusher.new.flush
-        Sidekiq::Grouping::Lazarus.new.revive if Sidekiq::Grouping::Config.reliable
+        Sidekiq::Grouping::Supervisor.new.requeue_expired if Sidekiq::Grouping::Config.reliable
       end
       @task.add_observer(@observer)
       logger.info(

--- a/lib/sidekiq/grouping.rb
+++ b/lib/sidekiq/grouping.rb
@@ -9,6 +9,7 @@ module Sidekiq::Grouping
   autoload :Config, "sidekiq/grouping/config"
   autoload :Redis, "sidekiq/grouping/redis"
   autoload :Batch, "sidekiq/grouping/batch"
+  autoload :ReliableBatch, "sidekiq/grouping/reliable_batch"
   autoload :Middleware, "sidekiq/grouping/middleware"
   autoload :Flusher, "sidekiq/grouping/flusher"
   autoload :FlusherObserver, "sidekiq/grouping/flusher_observer"

--- a/lib/sidekiq/grouping/batch.rb
+++ b/lib/sidekiq/grouping/batch.rb
@@ -120,11 +120,7 @@ module Sidekiq
             if Sidekiq::Grouping::Config.reliable
               begin
                 klass, queue = extract_worker_klass_and_queue(name)
-                if klass.constantize.get_sidekiq_options['batch_reliable'] == true
-                  Sidekiq::Grouping::ReliableBatch.new(klass, queue)
-                else
-                  new(klass, queue)
-                end
+                Sidekiq::Grouping::ReliableBatch.new(klass, queue)
               rescue NameError
                 nil
               end

--- a/lib/sidekiq/grouping/batch.rb
+++ b/lib/sidekiq/grouping/batch.rb
@@ -118,16 +118,12 @@ module Sidekiq
 
           redis.batches.map do |name|
             if Sidekiq::Grouping::Config.reliable
-              begin
-                klass, queue = extract_worker_klass_and_queue(name)
-                Sidekiq::Grouping::ReliableBatch.new(klass, queue)
-              rescue NameError
-                nil
-              end
+              klass, queue = extract_worker_klass_and_queue(name)
+              Sidekiq::Grouping::ReliableBatch.new(klass, queue)
             else
               new(*extract_worker_klass_and_queue(name))
             end
-          end.compact
+          end
         end
 
         def extract_worker_klass_and_queue(name)

--- a/lib/sidekiq/grouping/config.rb
+++ b/lib/sidekiq/grouping/config.rb
@@ -20,6 +20,11 @@ module Sidekiq::Grouping::Config
     options[:lock_ttl] || 1
   end
 
+  # Use reliable queues
+  config_accessor :reliable do
+    options[:reliable] || false
+  end
+
   # Option to override how Sidekiq::Grouping know about tests env
   config_accessor :tests_env do
     options[:tests_env] || (

--- a/lib/sidekiq/grouping/lazarus.rb
+++ b/lib/sidekiq/grouping/lazarus.rb
@@ -1,6 +1,8 @@
 class Sidekiq::Grouping::Lazarus
   def revive
     Sidekiq::Grouping::Batch.all.each do |batch|
+      next unless batch.is_a?(Sidekiq::Grouping::ReliableBatch)
+
       batch.requeue_expired
     end
   end

--- a/lib/sidekiq/grouping/lazarus.rb
+++ b/lib/sidekiq/grouping/lazarus.rb
@@ -1,0 +1,7 @@
+class Sidekiq::Grouping::Lazarus
+  def revive
+    Sidekiq::Grouping::Batch.all.each do |batch|
+      batch.requeue_expired
+    end
+  end
+end

--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -21,14 +21,12 @@ module Sidekiq
 
         redis.call('zadd', pending_jobs, current_time, this_job)
         local values = {}
-        local length = redis.call('llen', queue)
-        if limit > length then
-          limit = length
-        end
-        for i = 1, limit do 
+        for i = 1, math.min(limit, redis.call('llen', queue)) do 
           table.insert(values, redis.call('lmove', queue, this_job, 'left', 'right'))
         end
-        redis.call('srem', unique_messages, unpack(values))
+        if #values > 0 then
+          redis.call('srem', unique_messages, unpack(values))
+        end
 
         return {this_job, values}
       LUA

--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -50,10 +50,12 @@ module Sidekiq
         local unique_messages = KEYS[4]
 
         local to_requeue = redis.call('lrange', expired_queue, 0, -1)
-        for i = #to_requeue, 1, -1 do
+        for i = 1, #to_requeue do
           local message = to_requeue[i]
           if redis.call('sismember', unique_messages, message) == 0 then
-            redis.call('lmove', expired_queue, queue, 'right', 'left')
+            redis.call('lmove', expired_queue, queue, 'left', 'right')
+          else
+            redis.call('lpop', expired_queue)
           end
         end
         redis.call('zrem', pending_jobs, expired_queue)

--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -21,7 +21,7 @@ module Sidekiq
 
         redis.call('zadd', pending_jobs, current_time, this_job)
         local values = {}
-        for i = 1, limit do 
+        for i = 1, math.min(limit, redis.call('llen', queue)) do 
           table.insert(values, redis.call('lmove', queue, this_job, 'left', 'right'))
         end
         redis.call('srem', unique_messages, unpack(values))

--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -11,6 +11,23 @@ module Sidekiq
         return pluck_values
       SCRIPT
 
+      # keys: 1 = queue, 2 = unique message, 3 = pending jobs, 4 = current time, 5 = this job
+      RELIABLE_PLUCK_SCRIPT = <<-SCRIPT
+        redis.call('zadd', KEYS[3], KEYS[4], KEYS[5])
+        redis.call('renamenx', KEYS[1], KEYS[5])
+        local pluck_values = redis.call('lrange', KEYS[5], 0, -1)
+        local leftovers = redis.call('lrange', KEYS[5], ARGV[1], -1)
+        
+        for i = #leftovers, 1, -1 do 
+          redis.call('lpush', KEYS[1], v)
+        end
+
+        for k, v in pairs(pluck_values) do
+          redis.call('srem', KEYS[2], v)
+        end
+        return {KEYS[5], pluck_values}
+      SCRIPT
+
       def push_msg(name, msg, remember_unique = false)
         redis do |conn|
           conn.multi do |pipeline|
@@ -41,6 +58,14 @@ module Sidekiq
         redis { |conn| conn.eval PLUCK_SCRIPT, keys, args }
       end
 
+      def reliable_pluck(name, limit)
+        keys = [ns(name), unique_messages_key(name), pending_jobs(name), Time.now.to_i, this_job_name(name)]
+        args = [limit, 7.days]
+        script = RELIABLE_PLUCK_SCRIPT
+
+        redis { |conn| conn.eval script, keys, args }
+      end
+
       def get_last_execution_time(name)
         redis { |conn| conn.get(ns("last_execution_time:#{name}")) }
       end
@@ -64,10 +89,30 @@ module Sidekiq
         end
       end
 
+      def remove_from_pending(name, batch_name)
+        redis { |conn| conn.zrem(pending_jobs(name), batch_name) }
+      end
+
+      def requeue_expired(name, ttl=3600)
+        redis do |conn|
+          conn.zrangebyscore(pending_jobs(name), '0', Time.now.to_i - ttl).each do |expired|
+            conn.lmove(expired, ns(name), :right, :left)
+          end
+        end
+      end
+
       private
 
       def unique_messages_key name
         ns("#{name}:unique_messages")
+      end
+
+      def pending_jobs name
+        ns("#{name}:pending_jobs")
+      end
+
+      def this_job_name name
+        ns("#{name}:#{SecureRandom.hex}")
       end
 
       def ns(key = nil)

--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -17,11 +17,15 @@ module Sidekiq
         local pending_jobs = KEYS[3]
         local current_time = KEYS[4]
         local this_job = KEYS[5]
-        local limit = ARGV[1]
+        local limit = tonumber(ARGV[1])
 
         redis.call('zadd', pending_jobs, current_time, this_job)
         local values = {}
-        for i = 1, math.min(limit, redis.call('llen', queue)) do 
+        local length = redis.call('llen', queue)
+        if limit > length then
+          limit = length
+        end
+        for i = 1, limit do 
           table.insert(values, redis.call('lmove', queue, this_job, 'left', 'right'))
         end
         redis.call('srem', unique_messages, unpack(values))

--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -21,7 +21,7 @@ module Sidekiq
 
         redis.call('zadd', pending_jobs, current_time, this_job)
         local values = {}
-        for i = 1, math.min(limit, redis.call('llen', queue)) do 
+        for i = 1, math.min(limit, redis.call('llen', queue)) do
           table.insert(values, redis.call('lmove', queue, this_job, 'left', 'right'))
         end
         if #values > 0 then

--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -97,6 +97,7 @@ module Sidekiq
         redis do |conn|
           conn.zrangebyscore(pending_jobs(name), '0', Time.now.to_i - ttl).each do |expired|
             conn.lmove(expired, ns(name), :right, :left)
+            remove_from_pending(name, expired)
           end
         end
       end

--- a/lib/sidekiq/grouping/reliable_batch.rb
+++ b/lib/sidekiq/grouping/reliable_batch.rb
@@ -1,0 +1,38 @@
+module Sidekiq
+  module Grouping
+    class ReliableBatch < Batch
+      def flush
+        pending_name, chunk = pluck
+        return unless chunk
+
+        chunk.each_slice(chunk_size) do |subchunk|
+          Sidekiq::Client.push(
+            'class' => @worker_class,
+            'queue' => @queue,
+            'args' => [true, subchunk]
+          )
+        end
+        @redis.remove_from_pending(@name, pending_name)
+        set_current_time_as_last
+      end
+
+      def pluck
+        if @redis.lock(@name)
+          pending_name, items = @redis.reliable_pluck(@name, pluck_size)
+          items = items.map { |value| JSON.parse(value) }
+          [pending_name, items]
+        end
+      end
+
+      def requeue_expired
+        @redis.requeue_expired(@name, reliable_ttl)
+      end
+
+      private
+
+      def reliable_ttl
+        worker_class_options['batch_reliable_ttl'] || 3600
+      end
+    end
+  end
+end

--- a/lib/sidekiq/grouping/reliable_batch.rb
+++ b/lib/sidekiq/grouping/reliable_batch.rb
@@ -5,27 +5,23 @@ module Sidekiq
         pending_name, chunk = pluck
         return unless chunk
 
-        chunk.each_slice(chunk_size) do |subchunk|
-          Sidekiq::Client.push(
-            'class' => @worker_class,
-            'queue' => @queue,
-            'args' => [true, subchunk]
-          )
-        end
+        Sidekiq::Client.push_bulk(
+          'class' => @worker_class,
+          'queue' => @queue,
+          'args' => [true, chunk]
+        )
         @redis.remove_from_pending(@name, pending_name)
         set_current_time_as_last
       end
 
       def pluck
-        if @redis.lock(@name)
-          pending_name, items = @redis.reliable_pluck(@name, pluck_size)
-          items = items.map { |value| JSON.parse(value) }
-          [pending_name, items]
-        end
+        pending_name, items = @redis.reliable_pluck(@name, pluck_size)
+        items = items.map { |value| JSON.parse(value) }
+        [pending_name, items]
       end
 
       def requeue_expired
-        @redis.requeue_expired(@name, reliable_ttl)
+        @redis.requeue_expired(@name, worker_class_options['batch_unique'], reliable_ttl)
       end
 
       private

--- a/lib/sidekiq/grouping/reliable_batch.rb
+++ b/lib/sidekiq/grouping/reliable_batch.rb
@@ -5,7 +5,7 @@ module Sidekiq
         pending_name, chunk = pluck
         return unless chunk
 
-        Sidekiq::Client.push_bulk(
+        Sidekiq::Client.push(
           'class' => @worker_class,
           'queue' => @queue,
           'args' => [true, chunk]

--- a/lib/sidekiq/grouping/supervisor.rb
+++ b/lib/sidekiq/grouping/supervisor.rb
@@ -1,5 +1,5 @@
-class Sidekiq::Grouping::Lazarus
-  def revive
+class Sidekiq::Grouping::Supervisor
+  def requeue_expired
     Sidekiq::Grouping::Batch.all.each do |batch|
       next unless batch.is_a?(Sidekiq::Grouping::ReliableBatch)
 

--- a/spec/modules/batch_spec.rb
+++ b/spec/modules/batch_spec.rb
@@ -23,6 +23,11 @@ describe Sidekiq::Grouping::Batch do
       BatchedBothWorker.perform_async('bar')
       expect_batch(BatchedBothWorker, 'batched_both')
     end
+
+    it 'must not enqueue batched worker' do
+      ReliableBatchedSizeWorker.perform_async('bar')
+      expect_batch(ReliableBatchedSizeWorker, 'reliable_batched_size')
+    end
   end
 
   context 'checking if should flush' do
@@ -61,7 +66,7 @@ describe Sidekiq::Grouping::Batch do
   end
 
   context 'flushing' do
-    it 'must put wokrer to queue on flush' do
+    it 'must put worker to queue on flush' do
       batch = subject.new(BatchedSizeWorker.name, 'batched_size')
 
       expect(batch.could_flush?).to be_falsy

--- a/spec/modules/batch_spec.rb
+++ b/spec/modules/batch_spec.rb
@@ -28,6 +28,11 @@ describe Sidekiq::Grouping::Batch do
       ReliableBatchedSizeWorker.perform_async('bar')
       expect_batch(ReliableBatchedSizeWorker, 'reliable_batched_size')
     end
+
+    it 'must not enqueue batched worker' do
+      ReliableBatchedUniqueSizeWorker.perform_async('bar')
+      expect_batch(ReliableBatchedUniqueSizeWorker, 'reliable_batched_unique_size')
+    end
   end
 
   context 'checking if should flush' do

--- a/spec/modules/redis_spec.rb
+++ b/spec/modules/redis_spec.rb
@@ -112,13 +112,14 @@ describe Sidekiq::Grouping::Redis do
       it "requeues expired jobs that are not already present" do
         subject.push_msg(queue_name, "Message 1", true)
         subject.push_msg(queue_name, "Message 2", true)
-        pending_queue_name, _ = subject.reliable_pluck(queue_name, 2)
+        subject.push_msg(queue_name, "Message 3", true)
+        pending_queue_name, _ = subject.reliable_pluck(queue_name, 3)
         expect(subject.requeue_expired(queue_name, true, 500).size).to eq 0
         redis { |c| c.zincrby pending_jobs, -1000, pending_queue_name }
-        subject.push_msg(queue_name, "Message 1", true)
+        subject.push_msg(queue_name, "Message 2", true)
         expect(subject.requeue_expired(queue_name, true, 500).size).to eq 1
-        expect(redis { |c| c.llen key }).to eq 2
-        expect(redis { |c| c.lrange(key, 0, -1) }).to match_array(["Message 1", "Message 2"])
+        expect(redis { |c| c.llen key }).to eq 3
+        expect(redis { |c| c.lrange(key, 0, -1) }).to match_array(["Message 1", "Message 2", "Message 3"])
       end
 
       it "removes pending job once enqueued" do

--- a/spec/modules/redis_spec.rb
+++ b/spec/modules/redis_spec.rb
@@ -43,7 +43,7 @@ describe Sidekiq::Grouping::Redis do
     it "removes messages from queue" do
       subject.push_msg(queue_name, "Message 1")
       subject.push_msg(queue_name, "Message 2")
-      subject.reliable_pluck(queue_name, 2)
+      subject.reliable_pluck(queue_name, 1000)
       expect(redis { |c| c.llen key }).to eq 0
     end
 
@@ -64,7 +64,7 @@ describe Sidekiq::Grouping::Redis do
       expect(redis { |c| c.llen(pending_queue_name) }).to eq 2
     end
 
-    it "moves extra items back to the queue" do
+    it "keeps extra items in the queue" do
       subject.push_msg(queue_name, "Message 1", true)
       subject.push_msg(queue_name, "Message 2", true)
       subject.reliable_pluck(queue_name, 1)

--- a/spec/modules/redis_spec.rb
+++ b/spec/modules/redis_spec.rb
@@ -6,6 +6,7 @@ describe Sidekiq::Grouping::Redis do
   let(:queue_name)    { "my_queue" }
   let(:key)           { "batching:#{queue_name}" }
   let(:unique_key)    { "batching:#{queue_name}:unique_messages" }
+  let(:pending_jobs)  { "batching:#{queue_name}:pending_jobs" }
 
   describe "#push_msg" do
     it "adds message to queue" do
@@ -35,6 +36,75 @@ describe Sidekiq::Grouping::Redis do
       expect(redis { |c| c.scard unique_key }).to eq 2
       subject.pluck(queue_name, 2)
       expect(redis { |c| c.smembers unique_key }).to eq []
+    end
+  end
+
+  describe "#reliable_pluck" do
+    it "removes messages from queue" do
+      subject.push_msg(queue_name, "Message 1")
+      subject.push_msg(queue_name, "Message 2")
+      subject.reliable_pluck(queue_name, 2)
+      expect(redis { |c| c.llen key }).to eq 0
+    end
+
+    it "forgets unique messages" do
+      subject.push_msg(queue_name, "Message 1", true)
+      subject.push_msg(queue_name, "Message 2", true)
+      expect(redis { |c| c.scard unique_key }).to eq 2
+      subject.reliable_pluck(queue_name, 2)
+      expect(redis { |c| c.smembers unique_key }).to eq []
+    end
+
+    it "tracks the pending jobs" do
+      subject.push_msg(queue_name, "Message 1", true)
+      subject.push_msg(queue_name, "Message 2", true)
+      subject.reliable_pluck(queue_name, 2)
+      expect(redis { |c| c.zcount(pending_jobs, 0, Time.now.utc.to_i) }).to eq 1
+      pending_queue_name = redis { |c| c.zscan(pending_jobs, 0)[1][0][0] }
+      expect(redis { |c| c.llen(pending_queue_name) }).to eq 2
+    end
+
+    it "moves extra items back to the queue" do
+      subject.push_msg(queue_name, "Message 1", true)
+      subject.push_msg(queue_name, "Message 2", true)
+      subject.reliable_pluck(queue_name, 1)
+      expect(redis { |c| c.zcount(pending_jobs, 0, Time.now.utc.to_i) }).to eq 1
+      pending_queue_name = redis { |c| c.zscan(pending_jobs, 0)[1][0][0] }
+      expect(redis { |c| c.llen(pending_queue_name) }).to eq 1
+      expect(redis { |c| c.llen key }).to eq 1
+    end
+  end
+
+  describe "#remove_from_pending" do
+    it "removes pending jobs by name" do
+      subject.push_msg(queue_name, "Message 1", true)
+      subject.push_msg(queue_name, "Message 2", true)
+      pending_queue_name, _ = subject.reliable_pluck(queue_name, 2)
+      subject.remove_from_pending(queue_name, pending_queue_name)
+      expect(redis { |c| c.zcount(pending_jobs, 0, Time.now.utc.to_i) }).to eq 0
+    end
+  end
+
+  describe "#requeue_expired" do
+    it "requeues expired jobs" do
+      subject.push_msg(queue_name, "Message 1", true)
+      subject.push_msg(queue_name, "Message 2", true)
+      pending_queue_name, _ = subject.reliable_pluck(queue_name, 2)
+      expect(subject.requeue_expired(queue_name, 500).size).to eq 0
+      redis { |c| c.zincrby pending_jobs, -1000, pending_queue_name }
+      expect(subject.requeue_expired(queue_name, 500).size).to eq 1
+      expect(redis { |c| c.zcount(pending_jobs, 0, Time.now.utc.to_i) }).to eq 0
+      expect(redis { |c| c.llen key }).to eq 2
+    end
+
+    it "removes pending job once enqueued" do
+      subject.push_msg(queue_name, "Message 1", true)
+      subject.push_msg(queue_name, "Message 2", true)
+      pending_queue_name, _ = subject.reliable_pluck(queue_name, 2)
+      expect(subject.requeue_expired(queue_name, 500).size).to eq 0
+      redis { |c| c.zincrby pending_jobs, -1000, pending_queue_name }
+      expect(subject.requeue_expired(queue_name, 500).size).to eq 1
+      expect(redis { |c| c.zcount(pending_jobs, 0, Time.now.utc.to_i) }).to eq 0
     end
   end
 

--- a/spec/support/test_workers.rb
+++ b/spec/support/test_workers.rb
@@ -44,3 +44,14 @@ class BatchedUniqueArgsWorker
   def perform(foo)
   end
 end
+
+class ReliableBatchedSizeWorker
+  include Sidekiq::Worker
+
+  sidekiq_options(
+    queue: :reliable_batched_size, batch_flush_size: 3, batch_size: 2, batch_reliable: true
+  )
+
+  def perform(foo)
+  end
+end

--- a/spec/support/test_workers.rb
+++ b/spec/support/test_workers.rb
@@ -49,7 +49,18 @@ class ReliableBatchedSizeWorker
   include Sidekiq::Worker
 
   sidekiq_options(
-    queue: :reliable_batched_size, batch_flush_size: 3, batch_size: 2, batch_reliable: true
+    queue: :reliable_batched_size, batch_flush_size: 3, batch_size: 2, batch_ttl: 10
+  )
+
+  def perform(foo)
+  end
+end
+
+class ReliableBatchedUniqueSizeWorker
+  include Sidekiq::Worker
+
+  sidekiq_options(
+    queue: :reliable_batched_unique_size, batch_flush_size: 3, batch_size: 2, batch_ttl: 10, batch_unique: true
   )
 
   def perform(foo)


### PR DESCRIPTION
Background
================
This PR adds the ability to use reliable queues. There are two steps to enable this option:

1) Set Sidekiq::Grouping::Config.reliable to true in an initializer. This will enable the Lazarus module that revives expired jobs.
2) Set the Sidekiq `batch_reliable` worker option to true for the jobs that should use reliable queues.

I tried to keep the code backing the reliable queue option as separate as possible from the standard queues implementation so as to avoid any negative impact to the main workflow.

Testing
================
Tested in sandbox with messages sent to schools and districts and confirmed statuses are updated in batches. Added specs.

Risks
================
I haven't tested this with datasets larger than what we've got in sandbox.

Author Checklist
-----------------------

- [x] **A1** I added a Jira issue number
- [x] **A2** I added a Background section
- [x] **A3** I added automated tests, or they are not needed (explain why)
- [x] **A4** I described the manual tests I performed for this change
- [ ] **A5** I performance tested this with real data, or this does not affect performance
- [x] **A6** I described any risks with this change

Reviewer Checklist
-----------------------

- [ ] **R1** I understand the scope and function of this change
- [ ] **R2** This change fulfills the requirements in the Jira issue
- [ ] **R3** This change is good quality and provides a good user experience
- [ ] **R4** Future maintainers will be able to understand this code
- [ ] **R5** This code is sufficiently tested
- [ ] **R6** This change requires no further verification or testing