### PR TITLE
PDEV-4857: cleanup flushed jobs

### DIFF
--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -143,8 +143,8 @@ module Sidekiq
       def remove_from_pending(name, batch_name)
         redis do |conn|
           conn.multi do |pipeline|
-            pipeline.zrem(pending_jobs(name), batch_name)
             pipeline.del(batch_name)
+            pipeline.zrem(pending_jobs(name), batch_name)
           end
         end
       end

--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -142,8 +142,10 @@ module Sidekiq
 
       def remove_from_pending(name, batch_name)
         redis do |conn|
-          conn.zrem(pending_jobs(name), batch_name)
-          conn.del(batch_name)
+          conn.multi do |pipeline|
+            pipeline.zrem(pending_jobs(name), batch_name)
+            pipeline.del(batch_name)
+          end
         end
       end
 

--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -141,7 +141,10 @@ module Sidekiq
       end
 
       def remove_from_pending(name, batch_name)
-        redis { |conn| conn.zrem(pending_jobs(name), batch_name) }
+        redis do |conn|
+          conn.zrem(pending_jobs(name), batch_name)
+          conn.del(batch_name)
+        end
       end
 
       def requeue_expired(name, unique = false, ttl = 3600)

--- a/spec/modules/redis_spec.rb
+++ b/spec/modules/redis_spec.rb
@@ -80,8 +80,11 @@ describe Sidekiq::Grouping::Redis do
       subject.push_msg(queue_name, "Message 1", true)
       subject.push_msg(queue_name, "Message 2", true)
       pending_queue_name, _ = subject.reliable_pluck(queue_name, 2)
+      expect(redis { |c| c.lrange(pending_queue_name, 0, -1) }).to eq(['Message 1', 'Message 2'])
       subject.remove_from_pending(queue_name, pending_queue_name)
       expect(redis { |c| c.zcount(pending_jobs, 0, Time.now.utc.to_i) }).to eq 0
+      expect(redis { |c| c.lrange(pending_queue_name, 0, -1) }).to eq([])
+      expect(redis { |c| c.keys('*') }).not_to include(pending_queue_name)
     end
   end
 


### PR DESCRIPTION
Completes PDEV-4857

Background
================
This PR addresses an issue where we were not removing batches when we pushed them to Sidekiq for processing. The queues were _very_ durable...

Testing
================
Updated specs and tested in sandbox

Before:
```
> keys = Sidekiq.redis {|c| c.keys('batching:status_update_job:outcome:*') } 
> keys.size
=> 257

> Sidekiq.redis {|c| c.keys('batching:status_update_job:outcome:pending_jobs').size } 
=> 0 # this means all of the jobs have been completed

> Sidekiq.redis {|c| puts c.del(*keys) }
> 257
```

After:
```
> keys = Sidekiq.redis {|c| c.keys('batching:status_update_job:outcome:*') }
> keys.size
=> 0
```

Risks
================
None that I'm aware of for this specific PR. The risk will come when cleaning up the completed jobs in production before we deploy the text service with this change.

Author Checklist
-----------------------

- [x] **A1** I added a Jira issue number
- [x] **A2** I added a Background section
- [x] **A3** I added automated tests, or they are not needed (explain why)
- [x] **A4** I described the manual tests I performed for this change
- [x] **A5** I performance tested this with real data, or this does not affect performance
- [x] **A6** I described any risks with this change

Reviewer Checklist
-----------------------

- [ ] **R1** I understand the scope and function of this change
- [ ] **R2** This change fulfills the requirements in the Jira issue
- [ ] **R3** This change is good quality and provides a good user experience
- [ ] **R4** Future maintainers will be able to understand this code
- [ ] **R5** This code is sufficiently tested
- [ ] **R6** This change requires no further verification or testing