### PR TITLE
pdev-5066: requiring an Array of elements when batch_merge_array is used

### DIFF
--- a/lib/sidekiq/grouping/batch.rb
+++ b/lib/sidekiq/grouping/batch.rb
@@ -21,7 +21,12 @@ module Sidekiq
       end
 
       def merge(messages)
-        # messages is expected to be an array of elements that would normally be added using Sidekiq::Grouping::Batch#add
+        # messages is expected to be an array with a single item which is an array of elements that would normally be added using Sidekiq::Grouping::Batch#add
+        raise "batch_merge_array worker received #{messages.size} arguments. Expected a single Array of elements." if messages.size > 1
+
+        messages = messages.first
+        raise "batch_merge_array worker received type #{messages.class.name}. Expected Array." unless messages.is_a?(Array)
+
         messages.each_slice(1000) do |slice|
           @redis.push_messages(@name, slice, enqueue_similar_once?)
         end

--- a/spec/modules/batch_spec.rb
+++ b/spec/modules/batch_spec.rb
@@ -42,9 +42,29 @@ describe Sidekiq::Grouping::Batch do
         expect(mock_redis).to receive(:push_messages).with(anything, messages[0..999], anything).and_call_original
         expect(mock_redis).to receive(:push_messages).with(anything, messages[1000..1005], anything).and_call_original
 
-        BatchedBulkInsertWorker.perform_async(*messages)
+        BatchedBulkInsertWorker.perform_async(messages)
         batch = subject.new(BatchedBulkInsertWorker.name, 'batched_bulk_insert')
         expect(batch.size).to eq(1006)
+      end
+
+      it 'raises an exception if argument is not an array' do
+        failed = false
+        begin
+          BatchedBulkInsertWorker.perform_async('potato')
+        rescue StandardError => e
+          failed = true
+        end
+        expect(failed).to be_truthy
+      end
+
+      it 'raises an exception if argument is not a single-item array' do
+        failed = false
+        begin
+          BatchedBulkInsertWorker.perform_async(['potato'], ['tomato'])
+        rescue StandardError => e
+          failed = true
+        end
+        expect(failed).to be_truthy
       end
     end
   end

--- a/spec/modules/batch_spec.rb
+++ b/spec/modules/batch_spec.rb
@@ -57,7 +57,7 @@ describe Sidekiq::Grouping::Batch do
         expect(failed).to be_truthy
       end
 
-      it 'raises an exception if argument is not a single-item array' do
+      it 'raises an exception if argument is not a single array' do
         failed = false
         begin
           BatchedBulkInsertWorker.perform_async(['potato'], ['tomato'])


### PR DESCRIPTION
Completes PDEV-5066

Background
================
This PR adds checks to the merge function to protect against unexpected argument types. Previously, a developer could pass unexpected variable types.

Testing
================
Tested in staging with Smart Alerts

Risks
================
None

Author Checklist
-----------------------

- [x] **A1** I added a Jira issue number
- [x] **A2** I added a Background section
- [x] **A3** I added automated tests, or they are not needed (explain why)
- [x] **A4** I described the manual tests I performed for this change
- [x] **A5** I performance tested this with real data, or this does not affect performance
- [x] **A6** I described any risks with this change

Reviewer Checklist
-----------------------

- [ ] **R1** I understand the scope and function of this change
- [ ] **R2** This change fulfills the requirements in the Jira issue
- [ ] **R3** This change is good quality and provides a good user experience
- [ ] **R4** Future maintainers will be able to understand this code
- [ ] **R5** This code is sufficiently tested
- [ ] **R6** This change requires no further verification or testing