### PR TITLE
Sync upstream 2

### DIFF
--- a/lib/sidekiq/grouping/version.rb
+++ b/lib/sidekiq/grouping/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Grouping
-    VERSION = "1.1.0.ps1"
+    VERSION = "1.1.0.ps2"
   end
 end


### PR DESCRIPTION
Merges up latest changes from our fork's master into the `sync-upstream` branch, which is a branch intended to sync our fork with upstream, so we may unblock that branch and get our library fork up-to-date.

The core concern that this pr needed to address for a merge conflict was this commit https://github.com/ParentSquare/sidekiq-grouping/commit/d82e1a0a8a0b6bcc8ee02605511ae23af1686677 which uses a concurrent map with `compute_if_absent` to make sure that redis scripts are loaded once, and only once, and block on any concurrent access until a requisite script is loaded. The new code does this https://github.com/ParentSquare/sidekiq-grouping/pull/7/files#diff-7ade8b8b515b443214fb19efd0208b9fe804631e486d0b459c1ac772c76c7f53R104-R110 which loads the scripts at ruby load time. From my research it appears that load time happens only once for the program which means there is no concurrent access during this time, meaning no need to use a concurrency primitive to load the scripts. This approach loses the lazy evaluation of the existing approach, but the scripts are all small and presumably mostly used so i think this is a fine trade off.