### PR TITLE
Prevent loading scripts multiple times per process

### DIFF
--- a/lib/sidekiq/grouping/adapters/base_adapter.rb
+++ b/lib/sidekiq/grouping/adapters/base_adapter.rb
@@ -11,9 +11,9 @@ module Sidekiq
 
         def requeue_script(unique)
           if unique
-            RedisScripts::HASHES[:unique_requeue]
+            RedisScripts.script_hash(:unique_requeue)
           else
-            RedisScripts::HASHES[:requeue]
+            RedisScripts.script_hash(:requeue)
           end
         end
 

--- a/lib/sidekiq/grouping/adapters/redis_adapter.rb
+++ b/lib/sidekiq/grouping/adapters/redis_adapter.rb
@@ -19,13 +19,13 @@ module Sidekiq
             remember_unique.to_s
           ]
           argv = [messages]
-          redis_call(:evalsha, RedisScripts::HASHES[:merge_array], keys, argv)
+          redis_call(:evalsha, RedisScripts.script_hash(:merge_array), keys, argv)
         end
 
         def pluck(name, limit)
           keys = [ns(name), unique_messages_key(name)]
           args = [limit]
-          redis_call(:evalsha, RedisScripts::HASHES[:pluck], keys, args)
+          redis_call(:evalsha, RedisScripts.script_hash(:pluck), keys, args)
         end
 
         def reliable_pluck(name, limit)
@@ -39,7 +39,7 @@ module Sidekiq
           argv = [limit]
           redis_call(
             :evalsha,
-            RedisScripts::HASHES[:reliable_pluck],
+            RedisScripts.script_hash(:reliable_pluck),
             keys,
             argv
           )

--- a/lib/sidekiq/grouping/adapters/redis_client_adapter.rb
+++ b/lib/sidekiq/grouping/adapters/redis_client_adapter.rb
@@ -13,7 +13,7 @@ module Sidekiq
         def push_messages(name, messages, remember_unique: false)
           redis_call(
             :evalsha,
-            RedisScripts::HASHES[:merge_array],
+            RedisScripts.script_hash(:merge_array),
             5,
             ns("batches"),
             name,
@@ -27,7 +27,7 @@ module Sidekiq
         def pluck(name, limit)
           redis_call(
             :evalsha,
-            RedisScripts::HASHES[:pluck],
+            RedisScripts.script_hash(:pluck),
             2,
             ns(name),
             unique_messages_key(name),
@@ -38,7 +38,7 @@ module Sidekiq
         def reliable_pluck(name, limit)
           redis_call(
             :evalsha,
-            RedisScripts::HASHES[:reliable_pluck],
+            RedisScripts.script_hash(:reliable_pluck),
             5,
             ns(name),
             unique_messages_key(name),


### PR DESCRIPTION
A port of this commit which changes were originally omitted from a recent merge conflict resolution.
https://github.com/ParentSquare/sidekiq-grouping/commit/d82e1a0a8a0b6bcc8ee02605511ae23af1686677

The existing code loads all redis scripts during application load however that means we're waiting for requests to finish during application load which creates latency and potentially errors in boostrapping. Rather, we use the same mechanism from this other commit to lazy load redis scripts once and only once in a thread safe manner, so they are loaded once needed and not again.

follow up to https://github.com/ParentSquare/sidekiq-grouping/pull/9#issuecomment-1954969905